### PR TITLE
Bug report and bugfix for problem with invalid characters in thrown exception

### DIFF
--- a/Klarna.php
+++ b/Klarna.php
@@ -4421,27 +4421,27 @@ class Klarna
     /**
      * Fixes originalMessage encoding
      *
-     * @param $originalMessage
+     * @param string $originalMessage
      * @param string $inputEncoding (defaults to ISO-8859-1)
      * @param string $outputEncoding (defaults to UTF-8)
      * @return string
      */
     private function _fixMessageEncoding($originalMessage, $inputEncoding = 'ISO-8859-1', $outputEncoding = 'UTF-8')
     {
-        if (extension_loaded('intl') and class_exists('UConverter')) {
-            $fixedMessage = UConverter::transcode($originalMessage, $outputEncoding, $inputEncoding);
-            return $fixedMessage;
+        if (extension_loaded('intl')) {
+
+            return UConverter::transcode($originalMessage, $outputEncoding, $inputEncoding);
         }
         if (extension_loaded('mbstring')) {
-            $fixedMessage = mb_convert_encoding($originalMessage, $outputEncoding, $inputEncoding);
-            return $fixedMessage;
+
+            return mb_convert_encoding($originalMessage, $outputEncoding, $inputEncoding);
         }
         if (extension_loaded('iconv')) {
-            $fixedMessage = iconv($inputEncoding, $outputEncoding, $originalMessage);
-            return $fixedMessage;
+
+            return iconv($inputEncoding, $outputEncoding, $originalMessage);
         }
-        $fixedMessage = preg_replace('#[[:^ascii:]]#', '?', $originalMessage);
-        return $fixedMessage;
+
+        return preg_replace('#[[:^ascii:]]#', '?', $originalMessage);
     }
 } //End Klarna
 

--- a/Klarna.php
+++ b/Klarna.php
@@ -3666,7 +3666,8 @@ class Klarna
             $status = $xmlrpcresp->faultCode();
 
             if ($status !== 0) {
-                throw new KlarnaException($xmlrpcresp->faultString(), $status);
+                $errorMessage = $this->fixMessageEncoding($xmlrpcresp->faultString());
+                throw new KlarnaException($errorMessage, $status);
             }
 
             return php_xmlrpc_decode($xmlrpcresp->value());
@@ -4417,6 +4418,19 @@ class Klarna
         }
     }
 
+    /**
+     * Fixes originalMessage encoding
+     *
+     * @param string $originalMessage
+     * @return string
+     */
+    private function fixMessageEncoding($originalMessage)
+    {
+        $possibleInputEncodings = ['ISO-8859-1', 'UTF-8'];
+        $outputEncoding = mb_internal_encoding();
+
+        return mb_convert_encoding($originalMessage, $outputEncoding, $possibleInputEncodings);
+    }
 } //End Klarna
 
 /**


### PR DESCRIPTION
#### Bug description:

KlarnaException which can be attempted to be thrown at line of 3669 of Klarna.php might contain possibly invalid characters from incorrectly interpreted faultString().
#### Bug fix:

Converting the character encoding of the message before being used in constructing KlarnaException by adding and using method Klarna::fixMessageEncoding()
