### PR TITLE
Alternative bugfix for problem with invalid characters in thrown exception

### DIFF
--- a/Klarna.php
+++ b/Klarna.php
@@ -3651,12 +3651,23 @@ class Klarna
                 }
             }
 
-            //Send the message.
             $selectDateTime = microtime(true);
             if (self::$xmlrpcDebug) {
                 $this->xmlrpc->setDebug(2);
             }
+            //Save previous XML RPC client encoding settings.
+            $tmp_xmlrpc_defencoding = $GLOBALS['xmlrpc_defencoding'];
+            $tmp_xmlrpc_internalencoding = $GLOBALS['xmlrpc_internalencoding'];
+            //Set XML RPC client encoding settings.
+            $GLOBALS['xmlrpc_defencoding'] = 'ISO-8859-1';
+            $GLOBALS['xmlrpc_internalencoding'] = 'UTF-8';
+
+            //Send the message.
             $xmlrpcresp = $this->xmlrpc->send($msg);
+
+            //Restore previous XML RPC client encoding settings.
+            $GLOBALS['xmlrpc_defencoding'] = $tmp_xmlrpc_defencoding;
+            $GLOBALS['xmlrpc_internalencoding'] = $tmp_xmlrpc_internalencoding;
 
             //Calculate time and selectTime.
             $timeend = microtime(true);


### PR DESCRIPTION
This pull request provides alternative fix for bug described in
pull request https://github.com/klarna/php-xmlrpc/pull/1 and Issue https://github.com/klarna/php-xmlrpc/issues/2

Provided solution: sets encodings for PHP XML RPC client before XML RPC call
(and sets encodings to previous values after XML RPC call)
