### PR TITLE
Alternative bugfix for problem with invalid characters in thrown exception for 4.0 branch

### DIFF
--- a/src/Klarna.php
+++ b/src/Klarna.php
@@ -3604,12 +3604,23 @@ class Klarna
                 }
             }
 
-            //Send the message.
             $selectDateTime = microtime(true);
             if (self::$xmlrpcDebug) {
                 $this->xmlrpc->setDebug(2);
             }
+            //Save previous XML RPC client encoding settings.
+            $tmp_xmlrpc_defencoding = $GLOBALS['xmlrpc_defencoding'];
+            $tmp_xmlrpc_internalencoding = $GLOBALS['xmlrpc_internalencoding'];
+            //Set XML RPC client encoding settings.
+            $GLOBALS['xmlrpc_defencoding'] = 'ISO-8859-1';
+            $GLOBALS['xmlrpc_internalencoding'] = 'UTF-8';
+
+            //Send the message.
             $xmlrpcresp = $this->xmlrpc->send($msg);
+
+            //Restore previous XML RPC client encoding settings.
+            $GLOBALS['xmlrpc_defencoding'] = $tmp_xmlrpc_defencoding;
+            $GLOBALS['xmlrpc_internalencoding'] = $tmp_xmlrpc_internalencoding;
 
             //Calculate time and selectTime.
             $timeend = microtime(true);


### PR DESCRIPTION
This is bugfix (cherry picked from commit https://github.com/slavo2/php-xmlrpc/commit/f93a7ff16eff22891db86649c36474f5766c4775)
attempting to solve issue https://github.com/klarna/php-xmlrpc/issues/2
provided for 4.0 branch
