### PR TITLE
Changed the @return in docblock, missing datatype

### DIFF
--- a/src/Klarna/XMLRPC/Klarna.php
+++ b/src/Klarna/XMLRPC/Klarna.php
@@ -1870,7 +1870,7 @@ class Klarna
      * @throws Exception\KlarnaException when the RNO is not specified, or if an error
      *                                   is received from Klarna Online.
      *
-     * @return A string array with risk status and reservation number.
+     * @return array An array of strings containing risk status and reservation number.
      */
     public function activate(
         $rno,


### PR DESCRIPTION
![klarna](https://cloud.githubusercontent.com/assets/1155367/21989406/10c1903c-dc0b-11e6-90fc-88e07697140a.png)

As per `docs/examples/activate.php` the `activate()` method returns an array containing two elements. Since no datatype was given, the autodocumentation displayed this method as `return A`. Also changed wording (from *A string array* to *An array of strings*).

Very minor, but it was bothering me as I scrolled through the documentation.